### PR TITLE
Allow for multiple Google Maps API Keys in a single instance.

### DIFF
--- a/PokeAlarm/Discord/DiscordAlarm.py
+++ b/PokeAlarm/Discord/DiscordAlarm.py
@@ -1,6 +1,7 @@
 # Standard Library Imports
 import logging
 import requests
+import random
 # 3rd Party Imports
 # Local Imports
 from ..Alarm import Alarm
@@ -121,7 +122,7 @@ class DiscordAlarm(Alarm):
             'title': settings.pop('title', default['title']),
             'url': settings.pop('url', default['url']),
             'body': settings.pop('body', default['body']),
-            'map': get_static_map_url(settings.pop('map', self.__map), self.__static_map_key)
+            'map': get_static_map_url(settings.pop('map', self.__map), random.choice(self.__static_map_key))
         }
 
         reject_leftover_parameters(settings, "'Alert level in Discord alarm.")

--- a/PokeAlarm/LocationServices.py
+++ b/PokeAlarm/LocationServices.py
@@ -3,20 +3,19 @@ import logging
 import traceback
 # 3rd Party Imports
 import googlemaps
+import random
 # Local Imports
 
 log = logging.getLogger('LocService')
-
 
 # Class to handle Location Services
 class LocationService(object):
 
     # Initialize the APIs
     def __init__(self, api_key, locale, units):
-        self.__client = googlemaps.Client(key=api_key, timeout=3, retry_timeout=5)
-
         self.__locale = locale # Language to use for Geocoding results
         self.__units = units # imperial or metric
+        self.__google_key = api_key
 
         # For Reverse Location API
         self.__reverse_location = False
@@ -45,6 +44,7 @@ class LocationService(object):
     # Returns an array in the format [ Lat, Lng ]. Will exit if an error occurs.
     def get_location_from_name(self, location_name):
         try:
+            self.__client = googlemaps.Client(key=random.choice(self.__google_key), timeout=3, retry_timeout=5)
             result = self.__client.geocode(location_name, language=self.__locale)
             loc = result[0]['geometry']['location']  # Get the first (most likely) result
             latitude, longitude = loc.get("lat"), loc.get("lng")
@@ -74,6 +74,7 @@ class LocationService(object):
             'county': 'unknown', 'state': 'unknown', 'country': 'country'
         }
         try:
+            self.__client = googlemaps.Client(key=random.choice(self.__google_key), timeout=3, retry_timeout=5)
             result = self.__client.reverse_geocode(location, language=self.__locale)[0]
             loc = {}
             for item in result['address_components']:
@@ -115,6 +116,7 @@ class LocationService(object):
             return self.__walk_data_history[key]
         data = {'walk_dist': "unknown", 'walk_time': "unknown"}
         try:
+            self.__client = googlemaps.Client(key=random.choice(self.__google_key), timeout=3, retry_timeout=5)
             result = self.__client.distance_matrix(origin, dest,
                                                         mode='walking', units=self.__units, language=self.__locale)
             result = result.get('rows')[0].get('elements')[0]
@@ -141,6 +143,7 @@ class LocationService(object):
             return self.__bike_data_history[key]
         data = {'bike_dist': "unknown", 'bike_time': "unknown"}
         try:
+            self.__client = googlemaps.Client(key=random.choice(self.__google_key), timeout=3, retry_timeout=5)
             result = self.__client.distance_matrix(origin, dest,
                                                         mode='bicycling', units=self.__units, language=self.__locale)
             result = result.get('rows')[0].get('elements')[0]
@@ -167,6 +170,7 @@ class LocationService(object):
             return self.__driving_data_history[key]
         data = {'drive_dist': "unknown", 'drive_time': "unknown"}
         try:
+            self.__client = googlemaps.Client(key=random.choice(self.__google_key), timeout=3, retry_timeout=5)
             result = self.__client.distance_matrix(origin, dest,
                                                         mode='driving', units=self.__units, language=self.__locale)
             result = result.get('rows')[0].get('elements')[0]

--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -145,7 +145,7 @@ class Manager(object):
                     self.set_optional_args(str(alarm))
                     if _type == 'discord':
                         from Discord import DiscordAlarm
-                        self.__alarms.append(DiscordAlarm(alarm, max_attempts, random.choice(self.__google_key)))
+                        self.__alarms.append(DiscordAlarm(alarm, max_attempts, self.__google_key))
                     elif _type == 'facebook_page':
                         from FacebookPage import FacebookPageAlarm
                         self.__alarms.append(FacebookPageAlarm(alarm))
@@ -154,7 +154,7 @@ class Manager(object):
                         self.__alarms.append(PushbulletAlarm(alarm))
                     elif _type == 'slack':
                         from Slack import SlackAlarm
-                        self.__alarms.append(SlackAlarm(alarm, random.choice(self.__google_key)))
+                        self.__alarms.append(SlackAlarm(alarm, self.__google_key))
                     elif _type == 'telegram':
                         from Telegram import TelegramAlarm
                         self.__alarms.append(TelegramAlarm(alarm))

--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -7,6 +7,7 @@ import multiprocessing
 import traceback
 import re
 import sys
+import random
 # 3rd Party Imports
 import gipc
 # Local Imports
@@ -29,15 +30,11 @@ class Manager(object):
         self.__name = str(name).lower()
         log.info("----------- Manager '{}' is being created.".format(self.__name))
         self.__debug = debug
-
+        self.__google_key = google_key
         # Get the Google Maps API
-        self.__google_key = None
         self.__loc_service = None
-        if str(google_key).lower() != 'none':
-            self.__google_key = google_key
-            self.__loc_service = LocationService(google_key, locale, units)
-        else:
-            log.warning("NO GOOGLE API KEY SET - Reverse Location and Distance Matrix DTS will NOT be detected.")
+        self.__loc_service = LocationService(self.__google_key, locale, units)
+       
 
         self.__locale = Locale(locale)  # Setup the language-specific stuff
         self.__units = units  # type of unit used for distances
@@ -148,7 +145,7 @@ class Manager(object):
                     self.set_optional_args(str(alarm))
                     if _type == 'discord':
                         from Discord import DiscordAlarm
-                        self.__alarms.append(DiscordAlarm(alarm, max_attempts, self.__google_key))
+                        self.__alarms.append(DiscordAlarm(alarm, max_attempts, random.choice(self.__google_key)))
                     elif _type == 'facebook_page':
                         from FacebookPage import FacebookPageAlarm
                         self.__alarms.append(FacebookPageAlarm(alarm))
@@ -157,7 +154,7 @@ class Manager(object):
                         self.__alarms.append(PushbulletAlarm(alarm))
                     elif _type == 'slack':
                         from Slack import SlackAlarm
-                        self.__alarms.append(SlackAlarm(alarm, self.__google_key))
+                        self.__alarms.append(SlackAlarm(alarm, random.choice(self.__google_key)))
                     elif _type == 'telegram':
                         from Telegram import TelegramAlarm
                         self.__alarms.append(TelegramAlarm(alarm))

--- a/PokeAlarm/Slack/SlackAlarm.py
+++ b/PokeAlarm/Slack/SlackAlarm.py
@@ -1,6 +1,7 @@
 # Standard Library Imports
 import logging
 import re
+import random
 # 3rd Party Imports
 from slacker import Slacker
 # Local Imports
@@ -105,7 +106,7 @@ class SlackAlarm(Alarm):
             'title': settings.pop('title', default['title']),
             'url': settings.pop('url', default['url']),
             'body': settings.pop('body', default['body']),
-            'map': get_static_map_url(settings.pop('map', self.__map), self.__static_map_key)
+            'map': get_static_map_url(settings.pop('map', self.__map), random.choice(self.__static_map_key))
         }
         reject_leftover_parameters(settings, "'Alert level in Slack alarm.")
         return alert


### PR DESCRIPTION
## Description
Allows people to use multiple Google Maps Keys in a single instance of pokealarm.

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [ x] New feature (non-breaking change which adds functionality)

## Motivation and Context
With the increase in spawns it was becoming increasingly more difficult to keeps google maps api keys up and working. This will allow you to add mass amounts of keys to a single instance.

## How Has This Been Tested?
I'm running this on all 16 instances of PokeAlarm within my server. I also gave this code to a couple other scanners who are running it successfully.

